### PR TITLE
Update conference homepage header

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>台灣醫事聯合技能發展學會2025年會員大會暨學術研討會</title>
+    <title>台灣醫事聯合臨床技能發展學會 2025年會員大會暨學術研討會</title>
     <style>
         * {
             margin: 0;
@@ -13,7 +13,7 @@
         
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: linear-gradient(135deg, #0f1b2b 0%, #1f2d3d 60%, #27384a 100%);
             min-height: 100vh;
             color: #333;
         }
@@ -26,29 +26,87 @@
         }
         
         .header {
-            background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
+            position: relative;
+            overflow: hidden;
+            background: linear-gradient(140deg, rgba(31, 45, 61, 0.96) 0%, rgba(18, 35, 53, 0.97) 65%, rgba(11, 28, 48, 0.95) 100%);
             color: white;
             text-align: center;
-            padding: 20px 15px;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            padding: 45px 18px 60px;
+            box-shadow: 0 12px 40px rgba(10, 25, 40, 0.35);
         }
-        
-        .header h1 {
-            font-size: 1.4rem;
-            font-weight: 700;
-            margin-bottom: 8px;
-            line-height: 1.3;
+
+        .header::before {
+            content: '';
+            position: absolute;
+            top: -60px;
+            left: -80px;
+            width: 260px;
+            height: 260px;
+            background: radial-gradient(circle at center, rgba(79, 209, 197, 0.55) 0%, rgba(79, 209, 197, 0) 70%);
+            opacity: 0.7;
+            filter: blur(0.5px);
         }
-        
-        .header .subtitle {
-            font-size: 0.9rem;
-            opacity: 0.9;
-            margin-bottom: 5px;
-        }
-        
-        .header .location {
-            font-size: 0.8rem;
+
+        .header::after {
+            content: '';
+            position: absolute;
+            bottom: 20px;
+            left: 12%;
+            width: 76%;
+            height: 3px;
+            background: linear-gradient(90deg, rgba(79, 209, 197, 0), rgba(79, 209, 197, 0.85), rgba(99, 179, 237, 0));
             opacity: 0.8;
+        }
+
+        .header::before,
+        .header::after {
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        .header > * {
+            position: relative;
+            z-index: 1;
+        }
+
+        .header h1 {
+            font-size: 1.5rem;
+            font-weight: 700;
+            margin-bottom: 16px;
+            line-height: 1.35;
+            letter-spacing: 0.04em;
+            position: relative;
+        }
+
+        .header .subtitle {
+            font-size: 0.92rem;
+            opacity: 0.85;
+            margin-top: 18px;
+        }
+
+        .conference-theme {
+            display: inline-block;
+            position: relative;
+            margin: 0 auto;
+            padding: 0 14px 10px;
+            font-size: 1.08rem;
+            font-weight: 600;
+            letter-spacing: 0.08em;
+            background: linear-gradient(95deg, #4fd1c5 0%, #63b3ed 50%, #4299e1 100%);
+            -webkit-background-clip: text;
+            background-clip: text;
+            -webkit-text-fill-color: transparent;
+            text-shadow: 0 10px 30px rgba(79, 209, 197, 0.35);
+        }
+
+        .conference-theme::after {
+            content: '';
+            position: absolute;
+            left: 12%;
+            right: 12%;
+            bottom: 0;
+            height: 2px;
+            background: linear-gradient(90deg, rgba(79, 209, 197, 0.2), rgba(79, 209, 197, 0.8), rgba(99, 179, 237, 0.2));
         }
         
         .tabs {
@@ -297,10 +355,9 @@
 <body>
     <div class="container">
         <div class="header">
-            <h1>台灣醫事聯合技能發展學會<br>2025年會員大會暨學術研討會</h1>
+            <h1>台灣醫事聯合臨床技能發展學會<br>2025年會員大會暨學術研討會</h1>
+            <div class="conference-theme">數位轉型 × 跨域共融　重塑臨床技能教育的新未來</div>
             <div class="subtitle">學會研討會手冊</div>
-            <div class="location">奇美醫院第五醫療大樓5樓國際會議廳</div>
-            <div class="location">114年9月20日</div>
         </div>
         
         <div class="tabs">


### PR DESCRIPTION
## Summary
- correct the conference title text across the homepage hero section
- add the new themed tagline with gradient styling and updated deep-blue background accents
- remove outdated date and location details while refining the header decoration

## Testing
- Not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68c9e4ec3be88321abf02130da790dc1