### PR TITLE
Redirect membership tab to association signup page

### DIFF
--- a/index.html
+++ b/index.html
@@ -870,6 +870,10 @@
 
     <script>
         function showTab(tabName) {
+            if (tabName === 'membership') {
+                window.location.href = 'https://sub.chimei.org.tw/TSMCSD/index.php/vip/vip01';
+                return;
+            }
             const contents = document.querySelectorAll('.tab-content');
             contents.forEach(content => {
                 content.classList.remove('active');
@@ -903,6 +907,10 @@
         }
 
         function showTabProgrammatically(tabName) {
+            if (tabName === 'membership') {
+                window.location.href = 'https://sub.chimei.org.tw/TSMCSD/index.php/vip/vip01';
+                return;
+            }
             const contents = document.querySelectorAll('.tab-content');
             contents.forEach(content => {
                 content.classList.remove('active');


### PR DESCRIPTION
## Summary
- redirect the "入會說明" tab so it navigates to the official membership page
- ensure both direct tab clicks and programmatic tab changes send users to the external membership URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9e5f39c208321ba2c3459fcb85ec1