### PR TITLE
Fix OSCE page back link to index

### DIFF
--- a/osce.html
+++ b/osce.html
@@ -70,7 +70,7 @@
             font-weight: 500;
         }
         
-        .back-btn {
+        .back-button {
             position: absolute;
             left: 20px;
             top: 50%;
@@ -89,7 +89,7 @@
             gap: 8px;
         }
         
-        .back-btn:hover {
+        .back-button:hover {
             background: rgba(255,255,255,0.3);
             border-color: rgba(255,255,255,0.5);
             color: white;
@@ -293,7 +293,7 @@
         
         /* 響應式設計 */
         @media (max-width: 768px) {
-            .back-btn {
+            .back-button {
                 position: relative;
                 left: auto;
                 top: auto;
@@ -395,8 +395,8 @@
     <div class="container">
         <div class="header">
             <div class="header-content">
-                <a href="#" class="back-btn" id="backButton">
-                    ← 返回主頁
+                <a href="index.html" class="back-button">
+                    ← 返回首頁
                 </a>
                 <h1>臨床技能測驗(OSCE)優良教案</h1>
                 <div class="subtitle">台灣醫事聯合臨床技能發展學會2025會員大會暨學術研討會</div>
@@ -454,20 +454,7 @@
             try {
                 // 渲染所有 OSCE 教案卡片
                 renderCases(casesData);
-                
-                // 返回按鈕功能
-                const backBtn = document.getElementById('backButton');
-                if (backBtn) {
-                    backBtn.addEventListener('click', function(e) {
-                        e.preventDefault();
-                        if (document.referrer && document.referrer.includes(window.location.host)) {
-                            history.back();
-                        } else {
-                            window.location.href = 'index.html';
-                        }
-                    });
-                }
-                
+
             } catch (error) {
                 console.error('JavaScript執行錯誤:', error);
             }


### PR DESCRIPTION
## Summary
- update the OSCE back button to use an anchor that links directly to `index.html`
- rename the related CSS selector to `.back-button` to keep styles applied to the new element
- remove the JavaScript fallback that previously attempted to handle navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9e7416234832184d4f5d198d0be7b