### PR TITLE
Align posters page hero with homepage styling

### DIFF
--- a/posters02.html
+++ b/posters02.html
@@ -12,8 +12,8 @@
         }
         
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans TC', Roboto, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, #0f1b2b 0%, #1f2d3d 60%, #27384a 100%);
             min-height: 100vh;
             color: #333;
             line-height: 1.6;
@@ -36,53 +36,104 @@
         }
         
         .header {
-            background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%);
-            color: white;
-            text-align: center;
-            padding: 25px 20px;
-            box-shadow: 0 4px 15px rgba(0,0,0,0.15);
             position: relative;
             overflow: hidden;
+            background: linear-gradient(140deg, rgba(31, 45, 61, 0.96) 0%, rgba(18, 35, 53, 0.97) 65%, rgba(11, 28, 48, 0.95) 100%);
+            color: white;
+            text-align: center;
+            padding: 45px 18px 36px;
+            box-shadow: 0 12px 40px rgba(10, 25, 40, 0.35);
         }
-        
+
         .header::before {
             content: '';
             position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background-image: radial-gradient(circle at 20% 50%, rgba(255,255,255,0.1) 1px, transparent 1px),
-                              radial-gradient(circle at 80% 80%, rgba(255,255,255,0.1) 1px, transparent 1px);
-            background-size: 50px 50px;
-            opacity: 0.3;
+            top: -60px;
+            left: -80px;
+            width: 260px;
+            height: 260px;
+            background: radial-gradient(circle at center, rgba(79, 209, 197, 0.55) 0%, rgba(79, 209, 197, 0) 70%);
+            opacity: 0.7;
+            filter: blur(0.5px);
         }
-        
-        .header-content {
+
+        .header::after {
+            content: '';
+            position: absolute;
+            bottom: 10px;
+            left: 12%;
+            width: 76%;
+            height: 3px;
+            background: linear-gradient(90deg, rgba(79, 209, 197, 0), rgba(79, 209, 197, 0.85), rgba(99, 179, 237, 0));
+            opacity: 0.8;
+        }
+
+        .header::before,
+        .header::after {
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        .header > * {
             position: relative;
             z-index: 1;
         }
-        
+
         .header h1 {
             font-size: 1.5rem;
             font-weight: 700;
-            margin-bottom: 12px;
-            line-height: 1.4;
-            text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+            margin-bottom: 16px;
+            line-height: 1.35;
+            letter-spacing: 0.04em;
         }
-        
+
         .header .subtitle {
-            font-size: 1rem;
-            opacity: 0.95;
-            margin-bottom: 8px;
-            font-weight: 500;
+            font-size: 0.92rem;
+            opacity: 0.85;
+            margin-top: 18px;
+        }
+
+        .conference-theme {
+            display: inline-block;
+            position: relative;
+            margin: 0 auto;
+            padding: 0 14px 10px;
+            font-size: 1.08rem;
+            font-weight: 600;
+            letter-spacing: 0.05em;
+            line-height: 1.5;
+            max-width: 19em;
+            width: 100%;
+            text-align: center;
+            word-break: keep-all;
+            background: linear-gradient(95deg, #4fd1c5 0%, #63b3ed 50%, #4299e1 100%);
+            -webkit-background-clip: text;
+            background-clip: text;
+            -webkit-text-fill-color: transparent;
+            text-shadow: 0 10px 30px rgba(79, 209, 197, 0.35);
+        }
+
+        @media (min-width: 768px) {
+            .conference-theme {
+                width: auto;
+                max-width: none;
+            }
+        }
+
+        .conference-theme::after {
+            content: '';
+            position: absolute;
+            left: 12%;
+            right: 12%;
+            bottom: 0;
+            height: 2px;
+            background: linear-gradient(90deg, rgba(79, 209, 197, 0.2), rgba(79, 209, 197, 0.8), rgba(99, 179, 237, 0.2));
         }
         
         .back-btn {
             position: absolute;
-            left: 20px;
-            top: 50%;
-            transform: translateY(-50%);
+            left: 18px;
+            top: 18px;
             background: rgba(255,255,255,0.2);
             color: white;
             border: 2px solid rgba(255,255,255,0.3);
@@ -96,13 +147,13 @@
             align-items: center;
             gap: 8px;
         }
-        
+
         .back-btn:hover {
             background: rgba(255,255,255,0.3);
             border-color: rgba(255,255,255,0.5);
             color: white;
             text-decoration: none;
-            transform: translateY(-50%) translateX(-2px);
+            transform: translateX(-2px);
         }
         
         .content {
@@ -305,21 +356,15 @@
         
         /* 響應式設計 */
         @media (max-width: 768px) {
+            .header {
+                padding-top: 70px;
+            }
+
             .back-btn {
-                position: relative;
-                left: auto;
-                top: auto;
-                transform: none;
-                margin-bottom: 15px;
-                align-self: flex-start;
+                left: 12px;
+                top: 12px;
             }
-            
-            .header-content {
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-            }
-            
+
             .poster-header {
                 padding: 12px 15px;
                 gap: 10px;
@@ -410,13 +455,10 @@
 <body>
     <div class="container">
         <div class="header">
-            <div class="header-content">
-                <a href="#" class="back-btn" id="backButton">
-                    ← 返回主頁
-                </a>
-                <h1>優秀海報論文</h1>
-                <div class="subtitle">台灣醫事聯合技能發展學會 2025年會</div>
-            </div>
+            <a href="index.html" class="back-btn" id="backButton">← 返回主頁</a>
+            <h1>台灣醫事聯合臨床技能發展學會<br>2025年會員大會暨學術研討會</h1>
+            <div class="conference-theme">數位轉型 × 跨域共融<wbr>　重塑臨床技能教育的新未來</div>
+            <div class="subtitle">優秀海報論文</div>
         </div>
         
         <main class="content main-content">
@@ -883,20 +925,6 @@
             }, 4000);
         }
                 
-                // 返回按鈕功能
-                const backBtn = document.getElementById('backButton');
-                if (backBtn) {
-                    backBtn.addEventListener('click', function(e) {
-                        e.preventDefault();
-                        
-                        if (document.referrer && document.referrer.includes(window.location.host)) {
-                            history.back();
-                        } else {
-                            // 如果沒有來源頁面，返回主頁
-                            window.location.href = 'index.html';
-                        }
-                    });
-                }
             } catch (error) {
                 console.error('JavaScript執行錯誤:', error);
             }


### PR DESCRIPTION
## Summary
- restyle the 優秀海報論文 hero section to reuse the homepage gradient, typography, and conference theme banner
- center the new subtitle label with the updated 優秀海報論文 text while keeping the back button available
- adjust responsive spacing so the hero remains legible on smaller screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caab0d43448321aec4deed11603187