### PR TITLE
Improve info row layout on poster pages

### DIFF
--- a/eposters.html
+++ b/eposters.html
@@ -251,21 +251,27 @@
         
         .info-row {
             display: flex;
-            margin-bottom: 6px;
             align-items: flex-start;
+            margin-bottom: 6px;
+            gap: 6px;
             font-size: 0.85rem;
+            flex-wrap: nowrap;
         }
-        
+
         .label {
             font-weight: 600;
             color: #2c3e50;
             min-width: 65px;
             flex-shrink: 0;
+            white-space: nowrap;
         }
-        
+
         .value {
             color: #555;
             font-weight: 500;
+            flex: 1;
+            min-width: 0;
+            word-break: break-word;
         }
         
         .site-footer {
@@ -328,8 +334,9 @@
             .info-row {
                 font-size: 0.8rem;
                 margin-bottom: 5px;
+                gap: 4px;
             }
-            
+
             .label {
                 min-width: 60px;
             }
@@ -365,19 +372,17 @@
             }
             
             .info-row {
-                flex-direction: column;
-                gap: 2px;
+                gap: 4px;
                 margin-bottom: 4px;
             }
-            
+
             .label {
                 min-width: auto;
                 font-size: 0.75rem;
             }
-            
+
             .value {
                 font-size: 0.75rem;
-                padding-left: 10px;
             }
         }
         

--- a/posters02.html
+++ b/posters02.html
@@ -225,20 +225,26 @@
         
         .info-row {
             display: flex;
-            margin-bottom: 10px;
             align-items: flex-start;
+            margin-bottom: 10px;
+            gap: 6px;
+            flex-wrap: nowrap;
         }
-        
+
         .label {
             font-weight: 600;
             color: #2c3e50;
             min-width: 80px;
             flex-shrink: 0;
+            white-space: nowrap;
         }
-        
+
         .value {
             color: #555;
             font-weight: 500;
+            flex: 1;
+            min-width: 0;
+            word-break: break-word;
         }
         
         .committee-feedback {
@@ -386,19 +392,17 @@
             }
             
             .info-row {
-                flex-direction: column;
-                gap: 2px;
+                gap: 4px;
                 margin-bottom: 8px;
             }
-            
+
             .label {
                 min-width: auto;
                 font-size: 0.85rem;
             }
-            
+
             .value {
                 font-size: 0.85rem;
-                padding-left: 10px;
             }
             
             .feedback-text {


### PR DESCRIPTION
## Summary
- keep communication author and institution fields on the same line across poster layouts by updating info row flex styling
- allow labels to remain unbroken while letting values wrap within their container for better responsiveness on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caabbac0c0832180408363bfb33b67