### PR TITLE
Adjust page headers and back buttons

### DIFF
--- a/eposters.html
+++ b/eposters.html
@@ -123,37 +123,48 @@
             background: linear-gradient(90deg, rgba(79, 209, 197, 0.2), rgba(79, 209, 197, 0.8), rgba(99, 179, 237, 0.2));
         }
 
-        .header .subtitle {
-            font-size: 0.92rem;
-            opacity: 0.85;
+        .page-title-wrapper {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 16px;
             margin-top: 18px;
         }
 
-        .back-btn {
-            position: absolute;
-            left: 18px;
-            top: 24px;
+        .header .subtitle {
+            font-size: clamp(2rem, 6vw, 2.8rem);
+            font-weight: 800;
+            letter-spacing: 0.08em;
+            line-height: 1.2;
+            margin: 0;
+            color: #fff;
+            text-shadow: 0 6px 22px rgba(79, 209, 197, 0.4);
+        }
+
+        .header-back {
             background: rgba(255, 255, 255, 0.2);
             color: white;
             border: 2px solid rgba(255, 255, 255, 0.3);
-            padding: 10px 15px;
-            border-radius: 25px;
+            padding: 10px 16px;
+            border-radius: 999px;
             text-decoration: none;
             font-weight: 600;
-            font-size: 0.9rem;
+            font-size: 0.95rem;
             display: inline-flex;
             align-items: center;
             gap: 8px;
             transition: all 0.3s ease;
-            z-index: 2;
+            backdrop-filter: blur(4px);
+            white-space: nowrap;
         }
 
-        .back-btn:hover,
-        .back-btn:focus {
+        .header-back:hover,
+        .header-back:focus {
             background: rgba(255, 255, 255, 0.3);
             border-color: rgba(255, 255, 255, 0.5);
             color: white;
             transform: translateX(-2px);
+            text-decoration: none;
         }
 
         .content {
@@ -348,16 +359,13 @@
         
         /* 響應式設計 */
         @media (max-width: 768px) {
-            .header {
-                display: flex;
-                flex-direction: column;
-                align-items: center;
+            .page-title-wrapper {
+                gap: 12px;
             }
 
-            .back-btn {
-                position: static;
-                margin-bottom: 18px;
-                align-self: flex-start;
+            .header-back {
+                font-size: 0.9rem;
+                padding: 9px 14px;
             }
 
             .eposter-header {
@@ -395,7 +403,17 @@
                 padding-top: 28px;
             }
 
-            .header > *:not(.back-btn) {
+            .page-title-wrapper {
+                flex-direction: column;
+                gap: 10px;
+            }
+
+            .header-back {
+                font-size: 0.85rem;
+                padding: 8px 12px;
+            }
+
+            .header > *:not(.page-title-wrapper) {
                 width: 100%;
             }
 
@@ -451,10 +469,12 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="index.html" class="back-btn">← 返回主頁</a>
             <h1>台灣醫事聯合臨床技能發展學會<br>2025年會員大會暨學術研討會</h1>
             <div class="conference-theme">數位轉型 × 跨域共融<wbr>　重塑臨床技能教育的新未來</div>
-            <div class="subtitle">E-Poster</div>
+            <div class="page-title-wrapper">
+                <a href="index.html" class="header-back">← 返回主頁</a>
+                <div class="subtitle">E-Poster</div>
+            </div>
         </div>
 
         <main class="content main-content">

--- a/osce.html
+++ b/osce.html
@@ -133,32 +133,43 @@
             }
         }
 
-        .header .subtitle {
-            font-size: 0.92rem;
-            opacity: 0.85;
-            margin-top: 4px;
-            line-height: 1.5;
+        .page-title-wrapper {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 16px;
+            margin-top: 0;
         }
-        
-        .back-button {
-            position: absolute;
-            left: 20px;
-            top: 24px;
-            background: rgba(255,255,255,0.2);
+
+        .header .subtitle {
+            font-size: clamp(2rem, 6vw, 2.8rem);
+            font-weight: 800;
+            letter-spacing: 0.08em;
+            line-height: 1.2;
+            margin: 0;
+            color: #fff;
+            text-shadow: 0 6px 22px rgba(142, 68, 173, 0.4);
+        }
+
+        .header-back {
+            background: rgba(255, 255, 255, 0.2);
             color: white;
-            border: 2px solid rgba(255,255,255,0.3);
-            padding: 10px 15px;
-            border-radius: 25px;
+            border: 2px solid rgba(255, 255, 255, 0.3);
+            padding: 10px 16px;
+            border-radius: 999px;
             text-decoration: none;
             font-weight: 600;
-            font-size: 0.9rem;
-            transition: all 0.3s ease;
+            font-size: 0.95rem;
             display: inline-flex;
             align-items: center;
             gap: 8px;
+            transition: all 0.3s ease;
+            backdrop-filter: blur(4px);
+            white-space: nowrap;
         }
 
-        .back-button:hover {
+        .header-back:hover,
+        .header-back:focus {
             background: rgba(255,255,255,0.3);
             border-color: rgba(255,255,255,0.5);
             color: white;
@@ -378,17 +389,17 @@
                 padding: 38px 16px 28px;
             }
 
-            .back-button {
-                position: relative;
-                left: 0;
-                top: 0;
-                margin-bottom: 16px;
-                margin-right: auto;
-                transform: none;
+            .page-title-wrapper {
+                gap: 12px;
+            }
+
+            .header-back {
+                font-size: 0.9rem;
+                padding: 9px 14px;
             }
 
             .header-content {
-                gap: 12px;
+                gap: 14px;
             }
 
             .case-header {
@@ -421,6 +432,20 @@
         }
         
         @media (max-width: 480px) {
+            .page-title-wrapper {
+                flex-direction: column;
+                gap: 10px;
+            }
+
+            .header-back {
+                font-size: 0.85rem;
+                padding: 8px 12px;
+            }
+
+            .header-content > *:not(.page-title-wrapper) {
+                width: 100%;
+            }
+
             .content {
                 padding: 15px;
             }
@@ -470,11 +495,13 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="index.html" class="back-button">← 返回主頁</a>
             <div class="header-content">
                 <h1>台灣醫事聯合臨床技能發展學會<br>2025年會員大會暨學術研討會</h1>
                 <div class="conference-theme">數位轉型 × 跨域共融<wbr>　重塑臨床技能教育的新未來</div>
-                <div class="subtitle">臨床技能測驗(OSCE)優良教案</div>
+                <div class="page-title-wrapper">
+                    <a href="index.html" class="header-back">← 返回主頁</a>
+                    <div class="subtitle">臨床技能測驗(OSCE)優良教案</div>
+                </div>
             </div>
         </div>
         

--- a/posters02.html
+++ b/posters02.html
@@ -87,12 +87,6 @@
             letter-spacing: 0.04em;
         }
 
-        .header .subtitle {
-            font-size: 0.92rem;
-            opacity: 0.85;
-            margin-top: 18px;
-        }
-
         .conference-theme {
             display: inline-block;
             position: relative;
@@ -130,25 +124,43 @@
             background: linear-gradient(90deg, rgba(79, 209, 197, 0.2), rgba(79, 209, 197, 0.8), rgba(99, 179, 237, 0.2));
         }
         
-        .back-btn {
-            position: absolute;
-            left: 18px;
-            top: 18px;
-            background: rgba(255,255,255,0.2);
-            color: white;
-            border: 2px solid rgba(255,255,255,0.3);
-            padding: 10px 15px;
-            border-radius: 25px;
-            text-decoration: none;
-            font-weight: 600;
-            font-size: 0.9rem;
-            transition: all 0.3s ease;
-            display: flex;
+        .page-title-wrapper {
+            display: inline-flex;
             align-items: center;
-            gap: 8px;
+            justify-content: center;
+            gap: 16px;
+            margin-top: 18px;
         }
 
-        .back-btn:hover {
+        .header .subtitle {
+            font-size: clamp(2rem, 6vw, 2.8rem);
+            font-weight: 800;
+            letter-spacing: 0.08em;
+            line-height: 1.2;
+            margin: 0;
+            color: #fff;
+            text-shadow: 0 6px 22px rgba(99, 179, 237, 0.4);
+        }
+
+        .header-back {
+            background: rgba(255, 255, 255, 0.2);
+            color: white;
+            border: 2px solid rgba(255, 255, 255, 0.3);
+            padding: 10px 16px;
+            border-radius: 999px;
+            text-decoration: none;
+            font-weight: 600;
+            font-size: 0.95rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            transition: all 0.3s ease;
+            backdrop-filter: blur(4px);
+            white-space: nowrap;
+        }
+
+        .header-back:hover,
+        .header-back:focus {
             background: rgba(255,255,255,0.3);
             border-color: rgba(255,255,255,0.5);
             color: white;
@@ -363,12 +375,16 @@
         /* 響應式設計 */
         @media (max-width: 768px) {
             .header {
-                padding-top: 70px;
+                padding-top: 45px;
             }
 
-            .back-btn {
-                left: 12px;
-                top: 12px;
+            .page-title-wrapper {
+                gap: 12px;
+            }
+
+            .header-back {
+                font-size: 0.9rem;
+                padding: 9px 14px;
             }
 
             .poster-header {
@@ -406,6 +422,20 @@
         }
         
         @media (max-width: 480px) {
+            .page-title-wrapper {
+                flex-direction: column;
+                gap: 10px;
+            }
+
+            .header-back {
+                font-size: 0.85rem;
+                padding: 8px 12px;
+            }
+
+            .header > *:not(.page-title-wrapper) {
+                width: 100%;
+            }
+
             .content {
                 padding: 15px;
             }
@@ -459,10 +489,12 @@
 <body>
     <div class="container">
         <div class="header">
-            <a href="index.html" class="back-btn" id="backButton">← 返回主頁</a>
             <h1>台灣醫事聯合臨床技能發展學會<br>2025年會員大會暨學術研討會</h1>
             <div class="conference-theme">數位轉型 × 跨域共融<wbr>　重塑臨床技能教育的新未來</div>
-            <div class="subtitle">優秀海報論文</div>
+            <div class="page-title-wrapper">
+                <a href="index.html" class="header-back">← 返回主頁</a>
+                <div class="subtitle">優秀海報論文</div>
+            </div>
         </div>
         
         <main class="content main-content">


### PR DESCRIPTION
## Summary
- enlarge each page-specific title and add a shared page-title wrapper so the return-home button sits to its left
- restyle the new header-back button for consistent appearance across the E-Poster, 優秀海報論文, and OSCE pages
- tweak responsive rules so the new layout stays centered without adding extra header height on small screens

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cb0ab5970c83219f3e30f6fe96298f