### PR TITLE
Adjust eposter layout

### DIFF
--- a/eposters.html
+++ b/eposters.html
@@ -458,17 +458,13 @@
         </div>
 
         <main class="content main-content">
-            <div class="award-section">
-                💻 數位海報論文展示
-            </div>
-            
+            <input type="text" class="search-box" placeholder="🔍 搜尋論文題目、作者或機構..." id="searchInput">
+
             <div class="stats-section">
                 <h3>📊 統計資訊</h3>
                 <p>共收錄 62 篇 E-Poster 數位海報論文</p>
             </div>
-            
-            <input type="text" class="search-box" placeholder="🔍 搜尋論文題目、作者或機構..." id="searchInput">
-            
+
             <div class="eposters-grid" id="epostersGrid">
                 <!-- E-Poster 卡片將由 JavaScript 動態生成 -->
             </div>


### PR DESCRIPTION
## Summary
- remove the dedicated digital poster showcase banner section from the E-Poster page
- reposition the search box to appear above the statistics panel for easier access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb0b736cac8321a85a0d29fa07e345