### PR TITLE
Update physical poster page header

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@
         <div class="header">
             <h1>台灣醫事聯合臨床技能發展學會<br>2025年會員大會暨學術研討會</h1>
             <div class="conference-theme">數位轉型 × 跨域共融<wbr>　重塑臨床技能教育的新未來</div>
-            <div class="subtitle">學會研討會手冊</div>
+            <div class="subtitle">實體海報論文</div>
         </div>
         
         <main class="main-content">
@@ -686,8 +686,7 @@
         </div>
         
         <div id="posters" class="tab-content">
-            <h2 class="section-title">實體海報論文</h2>
-            
+
             <div class="schedule-item">
                 <div class="schedule-time">01</div>
                 <div class="schedule-content">


### PR DESCRIPTION
## Summary
- update the manual subtitle to read "實體海報論文"
- remove the redundant section heading from the physical poster tab content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb0d3454cc832184e8752f24285128