### PR TITLE
Update conference handbook subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -398,7 +398,7 @@
         <div class="header">
             <h1>台灣醫事聯合臨床技能發展學會<br>2025年會員大會暨學術研討會</h1>
             <div class="conference-theme">數位轉型 × 跨域共融<wbr>　重塑臨床技能教育的新未來</div>
-            <div class="subtitle">學會研討會手冊</div>
+            <div class="subtitle">學術研討會手冊</div>
         </div>
         
         <main class="main-content">


### PR DESCRIPTION
## Summary
- Update the homepage header subtitle to display 「學術研討會手冊」 instead of 「學會研討會手冊」.

## Testing
- Not run (not requested).

------
https://chatgpt.com/codex/tasks/task_e_68cb0df3d0d0832188e1b93942a84a6a