### PR TITLE
Align poster page header layout

### DIFF
--- a/eposters.html
+++ b/eposters.html
@@ -124,21 +124,25 @@
         }
 
         .page-title-wrapper {
-            display: inline-flex;
+            display: flex;
             align-items: center;
             justify-content: center;
-            gap: 16px;
-            margin-top: 18px;
+            gap: 14px;
+            margin: 18px auto 0;
+            width: 100%;
+            max-width: 520px;
         }
 
         .header .subtitle {
-            font-size: clamp(2rem, 6vw, 2.8rem);
-            font-weight: 800;
-            letter-spacing: 0.08em;
-            line-height: 1.2;
+            font-size: 1.5rem;
+            font-weight: 700;
+            letter-spacing: 0.05em;
+            line-height: 1.35;
             margin: 0;
             color: #fff;
             text-shadow: 0 6px 22px rgba(79, 209, 197, 0.4);
+            min-width: 0;
+            text-align: center;
         }
 
         .header-back {
@@ -156,6 +160,7 @@
             transition: all 0.3s ease;
             backdrop-filter: blur(4px);
             white-space: nowrap;
+            flex-shrink: 0;
         }
 
         .header-back:hover,
@@ -361,6 +366,7 @@
         @media (max-width: 768px) {
             .page-title-wrapper {
                 gap: 12px;
+                max-width: 480px;
             }
 
             .header-back {
@@ -404,8 +410,8 @@
             }
 
             .page-title-wrapper {
-                flex-direction: column;
                 gap: 10px;
+                max-width: 100%;
             }
 
             .header-back {
@@ -415,6 +421,10 @@
 
             .header > *:not(.page-title-wrapper) {
                 width: 100%;
+            }
+
+            .header .subtitle {
+                font-size: 1.5rem;
             }
 
             .content {

--- a/osce.html
+++ b/osce.html
@@ -134,21 +134,25 @@
         }
 
         .page-title-wrapper {
-            display: inline-flex;
+            display: flex;
             align-items: center;
             justify-content: center;
-            gap: 16px;
-            margin-top: 0;
+            gap: 14px;
+            margin: 0 auto;
+            width: 100%;
+            max-width: 520px;
         }
 
         .header .subtitle {
-            font-size: clamp(2rem, 6vw, 2.8rem);
-            font-weight: 800;
-            letter-spacing: 0.08em;
-            line-height: 1.2;
+            font-size: 1.5rem;
+            font-weight: 700;
+            letter-spacing: 0.05em;
+            line-height: 1.35;
             margin: 0;
             color: #fff;
             text-shadow: 0 6px 22px rgba(142, 68, 173, 0.4);
+            min-width: 0;
+            text-align: center;
         }
 
         .header-back {
@@ -166,6 +170,7 @@
             transition: all 0.3s ease;
             backdrop-filter: blur(4px);
             white-space: nowrap;
+            flex-shrink: 0;
         }
 
         .header-back:hover,
@@ -391,6 +396,7 @@
 
             .page-title-wrapper {
                 gap: 12px;
+                max-width: 480px;
             }
 
             .header-back {
@@ -433,8 +439,8 @@
         
         @media (max-width: 480px) {
             .page-title-wrapper {
-                flex-direction: column;
                 gap: 10px;
+                max-width: 100%;
             }
 
             .header-back {
@@ -444,6 +450,10 @@
 
             .header-content > *:not(.page-title-wrapper) {
                 width: 100%;
+            }
+
+            .header .subtitle {
+                font-size: 1.5rem;
             }
 
             .content {

--- a/posters02.html
+++ b/posters02.html
@@ -125,21 +125,25 @@
         }
         
         .page-title-wrapper {
-            display: inline-flex;
+            display: flex;
             align-items: center;
             justify-content: center;
-            gap: 16px;
-            margin-top: 18px;
+            gap: 14px;
+            margin: 18px auto 0;
+            width: 100%;
+            max-width: 520px;
         }
 
         .header .subtitle {
-            font-size: clamp(2rem, 6vw, 2.8rem);
-            font-weight: 800;
-            letter-spacing: 0.08em;
-            line-height: 1.2;
+            font-size: 1.5rem;
+            font-weight: 700;
+            letter-spacing: 0.05em;
+            line-height: 1.35;
             margin: 0;
             color: #fff;
             text-shadow: 0 6px 22px rgba(99, 179, 237, 0.4);
+            min-width: 0;
+            text-align: center;
         }
 
         .header-back {
@@ -157,6 +161,7 @@
             transition: all 0.3s ease;
             backdrop-filter: blur(4px);
             white-space: nowrap;
+            flex-shrink: 0;
         }
 
         .header-back:hover,
@@ -380,6 +385,7 @@
 
             .page-title-wrapper {
                 gap: 12px;
+                max-width: 480px;
             }
 
             .header-back {
@@ -423,8 +429,8 @@
         
         @media (max-width: 480px) {
             .page-title-wrapper {
-                flex-direction: column;
                 gap: 10px;
+                max-width: 100%;
             }
 
             .header-back {
@@ -434,6 +440,10 @@
 
             .header > *:not(.page-title-wrapper) {
                 width: 100%;
+            }
+
+            .header .subtitle {
+                font-size: 1.5rem;
             }
 
             .content {


### PR DESCRIPTION
## Summary
- match the page titles with the main event heading size across the E-Poster, 優秀海報論文, and OSCE pages
- keep the "返回主頁" button consistently to the left of the titles while preserving the existing header spacing on desktop and mobile

## Testing
- Not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cb3a5124c88321b0389acd1108ca87