### PR TITLE
Update 08:40 lecture handout link to open Google Drive in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,7 +436,7 @@
                     <div class="schedule-title">未來已來：數位科技如何重塑臨床技能教育</div>
                     <div class="schedule-speaker">講師：<a href="javascript:void(0)" class="speaker-link" onclick="showSpeaker('謝文祥')">謝文祥 部長</a>／義大醫療體系行政中心智慧醫療部</div>
                     <div class="schedule-speaker">座長：蘇慧真 理事長／奇美醫院藥劑部部長</div>
-                    <button class="lecture-btn" onclick="downloadLecture('謝文祥_數位科技重塑臨床技能教育')">📄 課程講義</button>
+                    <button class="lecture-btn" onclick="window.open('https://drive.google.com/file/d/1BxsipN4pWry9SBS1K8K-8LdGOMl5Yqyu/view?usp=drive_link', '_blank', 'noopener')">📄 課程講義</button>
                 </div>
             </div>
             


### PR DESCRIPTION
## Summary
- update the 08:40-09:20 lecture handout button to open the provided Google Drive link in a new browser tab while preserving the existing styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc008802108321a5311cd27447d3b9