### PR TITLE
Adjust handbook header styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,8 +108,9 @@
         }
 
         .header .subtitle {
-            font-size: 0.92rem;
-            opacity: 0.85;
+            font-size: 1.5rem;
+            font-weight: 700;
+            opacity: 0.95;
             margin-top: 18px;
         }
 
@@ -398,7 +399,7 @@
         <div class="header">
             <h1>台灣醫事聯合臨床技能發展學會<br>2025年會員大會暨學術研討會</h1>
             <div class="conference-theme">數位轉型 × 跨域共融<wbr>　重塑臨床技能教育的新未來</div>
-            <div class="subtitle">實體海報論文</div>
+            <div class="subtitle">學術研討會手冊</div>
         </div>
         
         <main class="main-content">


### PR DESCRIPTION
## Summary
- enlarge the handbook subtitle styling to match the main conference title for better visibility
- rename the handbook subtitle from "實體海報論文" to "學術研討會手冊"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc0197ead8832182e457b3c7d416bd