### PR TITLE
Update 13:40 lecture handout link

### DIFF
--- a/index.html
+++ b/index.html
@@ -498,7 +498,7 @@
                     <div class="schedule-title">學習歷程數據如何驅動醫學教育？從學習紀錄到個人化發展</div>
                     <div class="schedule-speaker">講師：<a href="javascript:void(0)" class="speaker-link" onclick="showSpeaker('李宜恭')">李宜恭 主任</a>／大林慈濟醫院急診部</div>
                     <div class="schedule-speaker">座長：么煥忠 常務理事／奇美醫院影像醫學部技術主任</div>
-                    <button class="lecture-btn" onclick="downloadLecture('李宜恭_學習歷程數據驅動醫學教育')">📄 課程講義</button>
+                    <button class="lecture-btn" onclick="window.open('https://drive.google.com/file/d/1MuFT0rO3Fq0LDoB0VtBFeFfD4p0h9Xe0/view?usp=sharing', '_blank', 'noopener')">📄 課程講義</button>
                 </div>
             </div>
             


### PR DESCRIPTION
## Summary
- update the 13:40-14:20 session lecture handout button to open the new Google Drive link in a new tab while keeping the existing styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc02ccea288321886cf3ba74a9fa31