### PR TITLE
Add tab navigation to E-Poster page

### DIFF
--- a/eposters.html
+++ b/eposters.html
@@ -123,6 +123,46 @@
             background: linear-gradient(90deg, rgba(79, 209, 197, 0.2), rgba(79, 209, 197, 0.8), rgba(99, 179, 237, 0.2));
         }
 
+        .tabs {
+            display: flex;
+            background: #f8f9fa;
+            border-bottom: 1px solid #ddd;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        .tab {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 15px 12px;
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: #666;
+            text-decoration: none;
+            border-bottom: 3px solid transparent;
+            white-space: nowrap;
+            transition: all 0.3s ease;
+            flex-shrink: 0;
+        }
+
+        .tab:hover,
+        .tab:focus {
+            color: #2c3e50;
+            background: rgba(52, 152, 219, 0.08);
+        }
+
+        .tab:focus-visible {
+            outline: 2px solid #3498db;
+            outline-offset: 2px;
+        }
+
+        .tab.active {
+            color: #2c3e50;
+            border-bottom-color: #3498db;
+            background: white;
+        }
+
         .page-title-wrapper {
             display: flex;
             align-items: center;
@@ -369,6 +409,15 @@
                 max-width: 480px;
             }
 
+            .tabs {
+                flex-wrap: nowrap;
+            }
+
+            .tab {
+                padding: 12px 10px;
+                font-size: 0.8rem;
+            }
+
             .header-back {
                 font-size: 0.9rem;
                 padding: 9px 14px;
@@ -403,7 +452,7 @@
                 min-width: 60px;
             }
         }
-        
+
         @media (max-width: 480px) {
             .header {
                 padding-top: 28px;
@@ -468,6 +517,11 @@
             .value {
                 font-size: 0.75rem;
             }
+
+            .tab {
+                padding: 10px 8px;
+                font-size: 0.75rem;
+            }
         }
         
         .highlight {
@@ -487,16 +541,29 @@
             </div>
         </div>
 
-        <main class="content main-content">
-            <input type="text" class="search-box" placeholder="🔍 搜尋論文題目、作者或機構..." id="searchInput">
+        <main class="main-content">
+            <nav class="tabs" aria-label="頁籤導覽">
+                <a class="tab" href="index.html#schedule">議程</a>
+                <a class="tab" href="index.html#speakers">講師簡歷</a>
+                <a class="tab" href="index.html#posters">實體海報論文</a>
+                <a class="tab" href="posters02.html">優秀海報論文</a>
+                <a class="tab active" href="eposters.html" aria-current="page">E-Poster</a>
+                <a class="tab" href="osce.html">OSCE教案</a>
+                <a class="tab" href="https://sub.chimei.org.tw/TSMCSD/index.php/vip/vip01" target="_blank" rel="noopener">入會說明</a>
+                <a class="tab" href="index.html#survey">滿意度調查</a>
+            </nav>
 
-            <div class="stats-section">
-                <h3>📊 統計資訊</h3>
-                <p>共收錄 61 篇 E-Poster 數位海報論文</p>
-            </div>
+            <div class="content">
+                <input type="text" class="search-box" placeholder="🔍 搜尋論文題目、作者或機構..." id="searchInput">
 
-            <div class="eposters-grid" id="epostersGrid">
-                <!-- E-Poster 卡片將由 JavaScript 動態生成 -->
+                <div class="stats-section">
+                    <h3>📊 統計資訊</h3>
+                    <p>共收錄 61 篇 E-Poster 數位海報論文</p>
+                </div>
+
+                <div class="eposters-grid" id="epostersGrid">
+                    <!-- E-Poster 卡片將由 JavaScript 動態生成 -->
+                </div>
             </div>
         </main>
 


### PR DESCRIPTION
## Summary
- add tabbed navigation styles to the E-Poster page to match the physical poster experience
- insert the navigation bar with the same links and highlight the current E-Poster tab
- tweak responsive spacing so the new tabs remain usable on smaller screens

## Testing
- not run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68cc14366c24832193f4153c85525c01