### PR TITLE
Update institution labels to service organizations

### DIFF
--- a/eposters.html
+++ b/eposters.html
@@ -488,7 +488,7 @@
         </div>
 
         <main class="content main-content">
-            <input type="text" class="search-box" placeholder="🔍 搜尋論文題目、作者或機構..." id="searchInput">
+            <input type="text" class="search-box" placeholder="🔍 搜尋論文題目、作者或服務機構..." id="searchInput">
 
             <div class="stats-section">
                 <h3>📊 統計資訊</h3>
@@ -628,7 +628,7 @@
                             <span class="value">${item.author}</span>
                         </div>
                         <div class="info-row">
-                            <span class="label">機構：</span>
+                            <span class="label">服務機構：</span>
                             <span class="value">${item.institution}</span>
                         </div>
                     </div>

--- a/posters02.html
+++ b/posters02.html
@@ -576,7 +576,7 @@
                             <span class="value">呂方君</span>
                         </div>
                         <div class="info-row">
-                            <span class="label">機構：</span>
+                            <span class="label">服務機構：</span>
                             <span class="value">亞東紀念醫院</span>
                         </div>
                         <div class="committee-feedback">
@@ -601,7 +601,7 @@
                             <span class="value">楊紫麟</span>
                         </div>
                         <div class="info-row">
-                            <span class="label">機構：</span>
+                            <span class="label">服務機構：</span>
                             <span class="value">屏東基督教醫院</span>
                         </div>
                         <div class="committee-feedback">
@@ -626,7 +626,7 @@
                             <span class="value">黃婉筠</span>
                         </div>
                         <div class="info-row">
-                            <span class="label">機構：</span>
+                            <span class="label">服務機構：</span>
                             <span class="value">高雄榮民總醫院</span>
                         </div>
                         <div class="committee-feedback">
@@ -651,7 +651,7 @@
                             <span class="value">林靖芸</span>
                         </div>
                         <div class="info-row">
-                            <span class="label">機構：</span>
+                            <span class="label">服務機構：</span>
                             <span class="value">亞東紀念醫院</span>
                         </div>
                         <div class="committee-feedback">
@@ -676,7 +676,7 @@
                             <span class="value">劉名宏</span>
                         </div>
                         <div class="info-row">
-                            <span class="label">機構：</span>
+                            <span class="label">服務機構：</span>
                             <span class="value">國泰綜合醫院</span>
                         </div>
                         <div class="committee-feedback">
@@ -701,7 +701,7 @@
                             <span class="value">辜馨儀</span>
                         </div>
                         <div class="info-row">
-                            <span class="label">機構：</span>
+                            <span class="label">服務機構：</span>
                             <span class="value">馬偕紀念醫院</span>
                         </div>
                         <div class="committee-feedback">
@@ -726,7 +726,7 @@
                             <span class="value">卓慧如</span>
                         </div>
                         <div class="info-row">
-                            <span class="label">機構：</span>
+                            <span class="label">服務機構：</span>
                             <span class="value">奇美醫院</span>
                         </div>
                         <div class="committee-feedback">
@@ -751,7 +751,7 @@
                             <span class="value">戴紋君</span>
                         </div>
                         <div class="info-row">
-                            <span class="label">機構：</span>
+                            <span class="label">服務機構：</span>
                             <span class="value">奇美醫院</span>
                         </div>
                         <div class="committee-feedback">
@@ -776,7 +776,7 @@
                             <span class="value">黃文琳</span>
                         </div>
                         <div class="info-row">
-                            <span class="label">機構：</span>
+                            <span class="label">服務機構：</span>
                             <span class="value">國立成功大學醫學院附設醫院</span>
                         </div>
                         <div class="committee-feedback">
@@ -801,7 +801,7 @@
                             <span class="value">范芳郡</span>
                         </div>
                         <div class="info-row">
-                            <span class="label">機構：</span>
+                            <span class="label">服務機構：</span>
                             <span class="value">臺北醫學大學附設醫院</span>
                         </div>
                         <div class="committee-feedback">


### PR DESCRIPTION
## Summary
- rename the search placeholder on the E-Poster page to reference service organizations
- relabel institution fields as service organizations on the E-Poster and 优秀海报 pages

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc15e135d883219d3e8d31bfde7eeb