### PR TITLE
Align E-Poster tab navigation with posters page

### DIFF
--- a/eposters.html
+++ b/eposters.html
@@ -123,6 +123,46 @@
             background: linear-gradient(90deg, rgba(79, 209, 197, 0.2), rgba(79, 209, 197, 0.8), rgba(99, 179, 237, 0.2));
         }
 
+        .tabs {
+            display: flex;
+            background: #f8f9fa;
+            border-bottom: 1px solid #ddd;
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        .tab {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 15px 12px;
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: #666;
+            text-decoration: none;
+            border-bottom: 3px solid transparent;
+            white-space: nowrap;
+            transition: all 0.3s ease;
+            flex-shrink: 0;
+        }
+
+        .tab:hover,
+        .tab:focus {
+            color: #2c3e50;
+            background: rgba(52, 152, 219, 0.08);
+        }
+
+        .tab:focus-visible {
+            outline: 2px solid #3498db;
+            outline-offset: 2px;
+        }
+
+        .tab.active {
+            color: #2c3e50;
+            border-bottom-color: #3498db;
+            background: white;
+        }
+
         .header .subtitle {
             font-size: 1.5rem;
             font-weight: 700;
@@ -426,7 +466,31 @@
             <div class="subtitle">E-Poster</div>
         </div>
 
+        <main class="main-content">
+            <nav class="tabs" aria-label="頁籤導覽">
+                <a class="tab" href="index.html#schedule">議程</a>
+                <a class="tab" href="index.html#speakers">講師簡歷</a>
+                <a class="tab" href="index.html#posters">實體海報論文</a>
+                <a class="tab" href="posters02.html">優秀海報論文</a>
+                <a class="tab active" href="eposters.html" aria-current="page">E-Poster</a>
+                <a class="tab" href="osce.html">OSCE教案</a>
+                <a class="tab" href="https://sub.chimei.org.tw/TSMCSD/index.php/vip/vip01" target="_blank" rel="noopener">入會說明</a>
+                <a class="tab" href="index.html#survey">滿意度調查</a>
+            </nav>
 
+            <div class="content">
+                <h2 class="section-title">E-Poster 數位海報論文</h2>
+
+                <div class="award-section">📚 2025 E-Poster 數位海報論文專區</div>
+
+                <div class="stats-section">
+                    <h3>投稿統計</h3>
+                    <p>共收錄 62 篇 E-Poster 數位海報論文</p>
+                </div>
+
+                <input type="search" id="searchInput" class="search-box" placeholder="搜尋標題、作者或服務機構..." aria-label="搜尋E-Poster論文">
+
+                <div id="epostersGrid" class="eposters-grid" role="list"></div>
             </div>
         </main>
 


### PR DESCRIPTION
## Summary
- add the tabbed navigation styles used on the physical posters page to eposters.html
- insert the shared tab markup with the E-Poster tab marked active and restore the page content container

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc65b2ed6c8321a58cb37f629fbfce