### PR TITLE
Align excellent posters header with physical posters page

### DIFF
--- a/posters02.html
+++ b/posters02.html
@@ -164,53 +164,13 @@
             background: white;
         }
 
-        .page-title-wrapper {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 14px;
-            margin: 18px auto 0;
-            width: 100%;
-            max-width: 520px;
-        }
-
         .header .subtitle {
             font-size: 1.5rem;
             font-weight: 700;
-            letter-spacing: 0.05em;
-            line-height: 1.35;
-            margin: 0;
+            opacity: 0.95;
+            margin-top: 18px;
             color: #fff;
-            text-shadow: 0 6px 22px rgba(99, 179, 237, 0.4);
-            min-width: 0;
-            text-align: center;
-        }
-
-        .header-back {
-            background: rgba(255, 255, 255, 0.2);
-            color: white;
-            border: 2px solid rgba(255, 255, 255, 0.3);
-            padding: 10px 16px;
-            border-radius: 999px;
-            text-decoration: none;
-            font-weight: 600;
-            font-size: 0.95rem;
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            transition: all 0.3s ease;
-            backdrop-filter: blur(4px);
-            white-space: nowrap;
-            flex-shrink: 0;
-        }
-
-        .header-back:hover,
-        .header-back:focus {
-            background: rgba(255,255,255,0.3);
-            border-color: rgba(255,255,255,0.5);
-            color: white;
-            text-decoration: none;
-            transform: translateX(-2px);
+            letter-spacing: 0.05em;
         }
         
         .content {
@@ -423,16 +383,6 @@
                 padding-top: 45px;
             }
 
-            .page-title-wrapper {
-                gap: 12px;
-                max-width: 480px;
-            }
-
-            .header-back {
-                font-size: 0.9rem;
-                padding: 9px 14px;
-            }
-
             .poster-header {
                 padding: 12px 15px;
                 gap: 10px;
@@ -466,22 +416,8 @@
                 padding: 10px;
             }
         }
-        
+
         @media (max-width: 480px) {
-            .page-title-wrapper {
-                gap: 10px;
-                max-width: 100%;
-            }
-
-            .header-back {
-                font-size: 0.85rem;
-                padding: 8px 12px;
-            }
-
-            .header > *:not(.page-title-wrapper) {
-                width: 100%;
-            }
-
             .header .subtitle {
                 font-size: 1.5rem;
             }
@@ -541,10 +477,7 @@
         <div class="header">
             <h1>台灣醫事聯合臨床技能發展學會<br>2025年會員大會暨學術研討會</h1>
             <div class="conference-theme">數位轉型 × 跨域共融<wbr>　重塑臨床技能教育的新未來</div>
-            <div class="page-title-wrapper">
-                <a href="index.html" class="header-back">← 返回主頁</a>
-                <div class="subtitle">優秀海報論文</div>
-            </div>
+            <div class="subtitle">優秀海報論文</div>
         </div>
         
         <main class="main-content">


### PR DESCRIPTION
## Summary
- update the excellent posters page header layout to mirror the physical posters page
- remove the back-to-home button and associated styles from the excellent posters page header

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc67a025b0832188e6ba4e47c8a0c9