### PR TITLE
Align OSCE header with poster layout

### DIFF
--- a/osce.html
+++ b/osce.html
@@ -79,19 +79,10 @@
             z-index: 1;
         }
 
-        .header-content {
-            max-width: 720px;
-            margin: 0 auto;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 14px;
-        }
-
         .header h1 {
             font-size: 1.5rem;
             font-weight: 700;
-            margin-bottom: 0;
+            margin-bottom: 16px;
             line-height: 1.35;
             letter-spacing: 0.04em;
         }
@@ -178,7 +169,7 @@
             align-items: center;
             justify-content: center;
             gap: 14px;
-            margin: 0 auto;
+            margin: 18px auto 0;
             width: 100%;
             max-width: 520px;
         }
@@ -190,36 +181,9 @@
             line-height: 1.35;
             margin: 0;
             color: #fff;
-            text-shadow: 0 6px 22px rgba(142, 68, 173, 0.4);
+            text-shadow: 0 6px 22px rgba(99, 179, 237, 0.4);
             min-width: 0;
             text-align: center;
-        }
-
-        .header-back {
-            background: rgba(255, 255, 255, 0.2);
-            color: white;
-            border: 2px solid rgba(255, 255, 255, 0.3);
-            padding: 10px 16px;
-            border-radius: 999px;
-            text-decoration: none;
-            font-weight: 600;
-            font-size: 0.95rem;
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            transition: all 0.3s ease;
-            backdrop-filter: blur(4px);
-            white-space: nowrap;
-            flex-shrink: 0;
-        }
-
-        .header-back:hover,
-        .header-back:focus {
-            background: rgba(255,255,255,0.3);
-            border-color: rgba(255,255,255,0.5);
-            color: white;
-            text-decoration: none;
-            transform: translateX(-2px);
         }
         
         .content {
@@ -431,21 +395,12 @@
         /* 響應式設計 */
         @media (max-width: 768px) {
             .header {
-                padding: 38px 16px 28px;
+                padding-top: 45px;
             }
 
             .page-title-wrapper {
                 gap: 12px;
                 max-width: 480px;
-            }
-
-            .header-back {
-                font-size: 0.9rem;
-                padding: 9px 14px;
-            }
-
-            .header-content {
-                gap: 14px;
             }
 
             .case-header {
@@ -483,12 +438,7 @@
                 max-width: 100%;
             }
 
-            .header-back {
-                font-size: 0.85rem;
-                padding: 8px 12px;
-            }
-
-            .header-content > *:not(.page-title-wrapper) {
+            .header > *:not(.page-title-wrapper) {
                 width: 100%;
             }
 
@@ -545,13 +495,10 @@
 <body>
     <div class="container">
         <div class="header">
-            <div class="header-content">
-                <h1>台灣醫事聯合臨床技能發展學會<br>2025年會員大會暨學術研討會</h1>
-                <div class="conference-theme">數位轉型 × 跨域共融<wbr>　重塑臨床技能教育的新未來</div>
-                <div class="page-title-wrapper">
-                    <a href="index.html" class="header-back">← 返回主頁</a>
-                    <div class="subtitle">臨床技能測驗(OSCE)優良教案</div>
-                </div>
+            <h1>台灣醫事聯合臨床技能發展學會<br>2025年會員大會暨學術研討會</h1>
+            <div class="conference-theme">數位轉型 × 跨域共融<wbr>　重塑臨床技能教育的新未來</div>
+            <div class="page-title-wrapper">
+                <div class="subtitle">臨床技能測驗(OSCE)優良教案</div>
             </div>
         </div>
         


### PR DESCRIPTION
## Summary
- match the OSCE page header spacing and styling with the physical poster page
- remove the redundant home navigation button from the OSCE header

## Testing
- No tests were run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68cc67bb35788321b96378eda3eac232