### PR TITLE
Update E-Poster page layout and statistics

### DIFF
--- a/eposters.html
+++ b/eposters.html
@@ -481,14 +481,11 @@
             <div class="content">
                 <h2 class="section-title">E-Poster 數位海報論文</h2>
 
-                <div class="award-section">📚 2025 E-Poster 數位海報論文專區</div>
+                <input type="search" id="searchInput" class="search-box" placeholder="搜尋標題、作者或服務機構..." aria-label="搜尋E-Poster論文">
 
                 <div class="stats-section">
-                    <h3>投稿統計</h3>
-                    <p>共收錄 62 篇 E-Poster 數位海報論文</p>
+                    <p>錄取統計，共收錄61篇E-Poster</p>
                 </div>
-
-                <input type="search" id="searchInput" class="search-box" placeholder="搜尋標題、作者或服務機構..." aria-label="搜尋E-Poster論文">
 
                 <div id="epostersGrid" class="eposters-grid" role="list"></div>
             </div>


### PR DESCRIPTION
## Summary
- remove the 2025 E-Poster digital poster banner block from the page
- swap the positions of the search input and statistics block for the E-Poster list
- update the statistics text to show the accepted total of 61 E-Posters

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cda6953c688321aa21b10448f35c02