### PR TITLE
Replace e-poster heading with mobile-friendly download button

### DIFF
--- a/eposters.html
+++ b/eposters.html
@@ -188,27 +188,48 @@
             }
         }
         
-        .section-title {
-            color: #2c3e50;
-            font-size: 1.4rem;
-            font-weight: 800;
-            margin-bottom: 25px;
-            padding-bottom: 12px;
-            border-bottom: 4px solid #3498db;
-            position: relative;
-            text-align: center;
+        .download-wrapper {
+            margin: 24px 0 20px;
+            display: flex;
+            justify-content: center;
         }
-        
-        .section-title::after {
-            content: '';
-            position: absolute;
-            bottom: -4px;
-            left: 50%;
-            transform: translateX(-50%);
-            width: 60px;
-            height: 4px;
-            background: #e74c3c;
-            border-radius: 2px;
+
+        .download-button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            width: 100%;
+            max-width: 340px;
+            padding: 16px 26px;
+            font-size: 1.05rem;
+            font-weight: 700;
+            font-family: inherit;
+            color: #ffffff;
+            text-decoration: none;
+            background: linear-gradient(120deg, #4fd1c5 0%, #63b3ed 50%, #4299e1 100%);
+            border-radius: 999px;
+            border: none;
+            cursor: pointer;
+            box-shadow: 0 16px 32px rgba(79, 209, 197, 0.28);
+            transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+        }
+
+        .download-button:hover,
+        .download-button:focus {
+            filter: brightness(1.07);
+            transform: translateY(-1px);
+            box-shadow: 0 18px 36px rgba(66, 153, 225, 0.28);
+        }
+
+        .download-button:active {
+            transform: translateY(0);
+            box-shadow: 0 10px 24px rgba(66, 153, 225, 0.25);
+        }
+
+        .download-button:focus-visible {
+            outline: 3px solid rgba(99, 179, 237, 0.45);
+            outline-offset: 3px;
         }
         
         .award-section {
@@ -408,8 +429,13 @@
                 padding: 15px;
             }
             
-            .section-title {
-                font-size: 1.2rem;
+            .download-wrapper {
+                margin: 18px 0 16px;
+            }
+
+            .download-button {
+                padding: 12px 20px;
+                font-size: 0.95rem;
             }
             
             .award-section {
@@ -479,7 +505,9 @@
             </nav>
 
             <div class="content">
-                <h2 class="section-title">E-Poster 數位海報論文</h2>
+                <div class="download-wrapper">
+                    <button type="button" class="download-button" aria-label="下載E-Poster摘要全文" onclick="downloadEposterAbstracts()">下載摘要全文</button>
+                </div>
 
                 <div class="award-section">📚 2025 E-Poster 數位海報論文專區</div>
 
@@ -698,6 +726,10 @@
                     institutionElement.innerHTML = originalInstitution;
                 }
             });
+        }
+
+        function downloadEposterAbstracts() {
+            alert('正在準備下載「E-Poster 摘要全文」...\n\n請聯繫會務人員取得摘要檔案。');
         }
 
         // 鍵盤導航支援


### PR DESCRIPTION
## Summary
- replace the E-Poster page heading with a centered mobile-friendly "下載摘要全文" call-to-action button
- style the new button for responsive layouts and add a helper alert that guides users to request the file

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cda7d0cec48321b88e3a87a666586b