### PR TITLE
Add download abstract button to posters page

### DIFF
--- a/posters02.html
+++ b/posters02.html
@@ -223,7 +223,53 @@
             font-size: 1.1rem;
             box-shadow: 0 4px 12px rgba(243, 156, 18, 0.3);
         }
-        
+
+        .download-abstract-button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            background: linear-gradient(135deg, #3498db, #2980b9);
+            color: #ffffff;
+            border: none;
+            border-radius: 999px;
+            padding: 12px 22px;
+            font-size: 1rem;
+            font-weight: 700;
+            margin: 0 auto 24px;
+            cursor: pointer;
+            width: min(260px, 100%);
+            box-shadow: 0 8px 18px rgba(52, 152, 219, 0.35);
+            transition: all 0.3s ease;
+        }
+
+        .download-abstract-button:hover,
+        .download-abstract-button:focus {
+            transform: translateY(-2px);
+            box-shadow: 0 10px 22px rgba(41, 128, 185, 0.4);
+            outline: none;
+        }
+
+        .download-abstract-button:active {
+            transform: translateY(0);
+            box-shadow: 0 6px 16px rgba(41, 128, 185, 0.35);
+        }
+
+        .download-abstract-button:disabled {
+            background: linear-gradient(135deg, #95a5a6, #7f8c8d);
+            box-shadow: none;
+            cursor: not-allowed;
+            opacity: 0.85;
+        }
+
+        @media (max-width: 600px) {
+            .download-abstract-button {
+                font-size: 0.95rem;
+                padding: 12px 18px;
+                letter-spacing: 0.5px;
+            }
+        }
+
         .posters-grid {
             display: flex;
             flex-direction: column;
@@ -496,6 +542,10 @@
                 <div class="award-section">
                     🏆 入選優秀海報論文 - 含評審意見
                 </div>
+
+                <button type="button" id="download-abstract-button" class="download-abstract-button">
+                    📄 下載摘要全文
+                </button>
 
                 <div class="posters-grid">
                 <div class="poster-card">
@@ -803,63 +853,68 @@
                     });
                 });
                 
-        // 下載優秀海報論文摘要功能
-        function downloadPosterAbstracts() {
-            const button = event.target;
-            const originalText = button.innerHTML;
-            
-            // 顯示下載狀態
-            button.innerHTML = '⏳ 準備下載中...';
-            button.disabled = true;
-            
-            setTimeout(function() {
-                button.innerHTML = '✅ 已通知下載';
-                
-                setTimeout(function() {
-                    button.innerHTML = originalText;
-                    button.disabled = false;
-                }, 2500);
-                
-                // 顯示下載提示
-                showNotification('正在準備「優秀海報論文摘要全文」下載，請聯繫會務人員取得完整檔案。');
-            }, 1000);
-        }
-        
-        // 通知系統
-        function showNotification(message) {
-            let notification = document.getElementById('download-notification');
-            if (!notification) {
-                notification = document.createElement('div');
-                notification.id = 'download-notification';
-                notification.style.cssText = `
-                    position: fixed;
-                    top: 20px;
-                    left: 50%;
-                    transform: translateX(-50%);
-                    background: linear-gradient(135deg, #27ae60, #2ecc71);
-                    color: white;
-                    padding: 15px 25px;
-                    border-radius: 25px;
-                    box-shadow: 0 5px 15px rgba(0,0,0,0.2);
-                    z-index: 1000;
-                    font-weight: 600;
-                    max-width: 90%;
-                    text-align: center;
-                    opacity: 0;
-                    transition: all 0.3s ease;
-                `;
-                document.body.appendChild(notification);
-            }
-            
-            notification.textContent = message;
-            notification.style.opacity = '1';
-            notification.style.transform = 'translateX(-50%) translateY(0)';
-            
-            setTimeout(function() {
-                notification.style.opacity = '0';
-                notification.style.transform = 'translateX(-50%) translateY(-20px)';
-            }, 4000);
-        }
+                const downloadButton = document.getElementById('download-abstract-button');
+                if (downloadButton) {
+                    downloadButton.addEventListener('click', downloadPosterAbstracts);
+                }
+
+                // 下載優秀海報論文摘要功能
+                function downloadPosterAbstracts(event) {
+                    const button = event.currentTarget;
+                    const originalText = button.innerHTML;
+
+                    // 顯示下載狀態
+                    button.innerHTML = '⏳ 準備下載中...';
+                    button.disabled = true;
+
+                    setTimeout(function() {
+                        button.innerHTML = '✅ 已通知下載';
+
+                        setTimeout(function() {
+                            button.innerHTML = originalText;
+                            button.disabled = false;
+                        }, 2500);
+
+                        // 顯示下載提示
+                        showNotification('正在準備「優秀海報論文摘要全文」下載，請聯繫會務人員取得完整檔案。');
+                    }, 1000);
+                }
+
+                // 通知系統
+                function showNotification(message) {
+                    let notification = document.getElementById('download-notification');
+                    if (!notification) {
+                        notification = document.createElement('div');
+                        notification.id = 'download-notification';
+                        notification.style.cssText = `
+                            position: fixed;
+                            top: 20px;
+                            left: 50%;
+                            transform: translateX(-50%);
+                            background: linear-gradient(135deg, #27ae60, #2ecc71);
+                            color: white;
+                            padding: 15px 25px;
+                            border-radius: 25px;
+                            box-shadow: 0 5px 15px rgba(0,0,0,0.2);
+                            z-index: 1000;
+                            font-weight: 600;
+                            max-width: 90%;
+                            text-align: center;
+                            opacity: 0;
+                            transition: all 0.3s ease;
+                        `;
+                        document.body.appendChild(notification);
+                    }
+
+                    notification.textContent = message;
+                    notification.style.opacity = '1';
+                    notification.style.transform = 'translateX(-50%) translateY(0)';
+
+                    setTimeout(function() {
+                        notification.style.opacity = '0';
+                        notification.style.transform = 'translateX(-50%) translateY(-20px)';
+                    }, 4000);
+                }
                 
             } catch (error) {
                 console.error('JavaScript執行錯誤:', error);


### PR DESCRIPTION
## Summary
- add a prominently styled "下載摘要全文" button beneath the優秀海報論文 award section
- ensure the new control uses responsive, mobile-friendly styling that matches the existing color palette
- connect the button to the existing notification flow so visitors see status feedback when requesting a download

## Testing
- not run (static HTML/CSS/JS change)


------
https://chatgpt.com/codex/tasks/task_e_68cdb405bc788321942fa4e3f6e0a94d