### PR TITLE
Center download button on poster page

### DIFF
--- a/posters02.html
+++ b/posters02.html
@@ -225,7 +225,7 @@
         }
 
         .download-abstract-button {
-            display: inline-flex;
+            display: flex;
             align-items: center;
             justify-content: center;
             gap: 8px;


### PR DESCRIPTION
## Summary
- center the "下載摘要全文" button on the excellent poster page by using a block-level flex button so auto margins apply

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cdb9fbdf0483219cfddf1017a44d8e